### PR TITLE
Add initial SFTP/SSH support

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -11,6 +11,7 @@ indent-after-paren=4
 disable=blacklisted-name,invalid-name,
         too-few-public-methods,no-self-use,
         wrong-import-position,
+        import-outside-toplevel,
         line-too-long,
         bad-continuation,
         fixme

--- a/expt/path_util.py
+++ b/expt/path_util.py
@@ -11,27 +11,29 @@ import shlex
 import subprocess
 import sys
 from typing import List, Sequence, Union
-
-# Options for gsutil. By default, gsutil is disabled as tf.io.gfile is
-# **much** faster than gsutil commands (for globbing and listing).
-USE_GSUTIL = bool(ast.literal_eval(os.environ.get('USE_GSUTIL', 'True')))
-IS_GSUTIL_AVAILABLE = find_executable("gsutil")
-GSUTIL_NO_MATCHES = 'One or more URLs matched no objects'
+from typing_extensions import Protocol
 
 PathType = Union[str, os.PathLike]
 
 
-def _import_gfile():
-  # Reference: https://www.tensorflow.org/api_docs/python/tf/io/gfile
-  try:
-    import tensorflow.io.gfile as gfile  # type: ignore
-    return gfile
-  except:
-    pass
+class PathUtilInterface(Protocol):
+  """Interface for path utils."""
 
-  raise RuntimeError("To be able to read GCP path (gs://...), "
-                     "tensorflow should be installed. "
-                     "(Cannot import tensorflow.io.gfile)")
+  @staticmethod
+  def supports(path: PathType) -> bool:
+    raise NotImplementedError
+
+  def glob(self, pattern: PathType) -> Sequence[str]:
+    raise NotImplementedError
+
+  def exists(self, path: PathType) -> bool:
+    raise NotImplementedError
+
+  def isdir(self, path: PathType) -> bool:
+    raise NotImplementedError
+
+  def open(self, path: PathType, *, mode='r'):
+    raise NotImplementedError
 
 
 def _to_path_string(path: PathType) -> str:
@@ -41,6 +43,117 @@ def _to_path_string(path: PathType) -> str:
     return path
   else:
     raise TypeError(str(type(path)))
+
+
+# ---------------------------------------------------------------------------
+# Local Files
+# ---------------------------------------------------------------------------
+
+
+class LocalPathUtil(PathUtilInterface):
+
+  @staticmethod
+  def supports(path: PathType) -> bool:
+    return True  # TODO Exclude other protocols
+
+  def glob(self, pattern: PathType) -> Sequence[str]:
+    pattern = _to_path_string(pattern)
+    return local_glob(pattern)
+
+  def exists(self, path: PathType) -> bool:
+    path = _to_path_string(path)
+    return os.path.exists(path)
+
+  def isdir(self, path: PathType) -> bool:
+    path = _to_path_string(path)
+    return os.path.isdir(path)
+
+  def open(self, path: PathType, *, mode='r'):
+    path = _to_path_string(path)
+    return io.open(path, mode=mode, encoding='utf-8')
+
+
+# ---------------------------------------------------------------------------
+# Google Cloud
+# ---------------------------------------------------------------------------
+
+# Options for gsutil. By default, gsutil is disabled as tf.io.gfile is
+# **much** faster than gsutil commands (for globbing and listing).
+USE_GSUTIL = bool(ast.literal_eval(os.environ.get('USE_GSUTIL', 'True')))
+IS_GSUTIL_AVAILABLE = find_executable("gsutil")
+GSUTIL_NO_MATCHES = 'One or more URLs matched no objects'
+
+
+class GCloudPathUtil(PathUtilInterface):
+
+  @staticmethod
+  def supports(path: PathType) -> bool:
+    return _to_path_string(path).startswith('gs://')
+
+  def glob(self, pattern: PathType) -> Sequence[str]:
+    pattern = _to_path_string(pattern)
+
+    # Bug: GCP glob does not match any directory on trailing slashes.
+    # https://github.com/GoogleCloudPlatform/gsutil/issues/444
+    pattern = pattern.rstrip('/')
+    if USE_GSUTIL:
+      try:
+        if pattern.endswith('/*'):
+          # A small optimization: 'gsutil ls foo/' is much faster
+          # than 'gsutil ls -d foo/*' (around 3x~5x)
+          return gsutil('ls', pattern.rstrip('*'))
+        else:
+          return gsutil('ls', '-d', pattern)
+      except GsCommandException as e:
+        if GSUTIL_NO_MATCHES in str(e):
+          return []
+        raise
+    else:
+      # A small optimization: when the pattern itself is a dir (no glob
+      # was used) or the globbing '*' is used only at the last segment,
+      # we can just simply list dir which is *much* faster than globbing.
+      if self.isdir(pattern):
+        return [pattern.rstrip('/')]
+      elif pattern.endswith('/*') and self.isdir(pattern.rstrip('*')):
+        dir_base = pattern.rstrip('*')
+        ls = _import_gfile().listdir(dir_base)
+        return [os.path.join(dir_base, entry) for entry in ls]
+      else:
+        return _import_gfile().glob(pattern)  # noqa
+
+  def exists(self, path: PathType) -> bool:
+    path = _to_path_string(path)
+
+    if USE_GSUTIL:
+      try:
+        return bool(gsutil('ls', '-d', path))
+      except GsCommandException as e:
+        if GSUTIL_NO_MATCHES in str(e):
+          return False
+        raise
+    else:
+      return _import_gfile().exists(path)  # noqa
+
+  def isdir(self, path: PathType) -> bool:
+    path = _to_path_string(path)
+    path = path.rstrip('/')
+    return _import_gfile().isdir(path)  # noqa
+
+  def open(self, path: PathType, *, mode='r'):
+    path = _to_path_string(path)
+    return _import_gfile().GFile(path, mode=mode)  # noqa
+
+
+def _import_gfile():
+  # Reference: https://www.tensorflow.org/api_docs/python/tf/io/gfile
+  try:
+    # pylint: disable-next=all
+    import tensorflow.io.gfile as gfile  # type: ignore
+    return gfile
+  except ImportError as ex:
+    raise RuntimeError("To be able to read GCP path (gs://...), "
+                       "tensorflow should be installed. "
+                       "(Cannot import tensorflow.io.gfile)") from ex
 
 
 class GsCommandException(RuntimeError):
@@ -86,79 +199,44 @@ def use_gsutil(value: bool):
     USE_GSUTIL = False
 
 
+# ---------------------------------------------------------------------------
+# Public Module Interface
+# ---------------------------------------------------------------------------
+
+BACKENDS = [
+    GCloudPathUtil(),
+    LocalPathUtil(),
+]
+
+
+def _choose_backend(path: PathType) -> PathUtilInterface:
+  for backend in BACKENDS:
+    if backend.supports(path):
+      return backend
+  raise ValueError(f"The path or URL `{path}` is not supported.")
+
+
 def glob(pattern: PathType) -> Sequence[str]:
   """A glob function, returning a list of paths matching a pathname pattern.
 
   It supports local file path (i.e., glob.glob) and Google Cloud Storage
   (i.e., gs://...) path via gfile.glob(...).
   """
-  pattern = _to_path_string(pattern)
-
-  if pattern.startswith('gs://'):
-    # Bug: GCP glob does not match any directory on trailing slashes.
-    # https://github.com/GoogleCloudPlatform/gsutil/issues/444
-    pattern = pattern.rstrip('/')
-    if USE_GSUTIL:
-      try:
-        if pattern.endswith('/*'):
-          # A small optimization: 'gsutil ls foo/' is much faster
-          # than 'gsutil ls -d foo/*' (around 3x~5x)
-          return gsutil('ls', pattern.rstrip('*'))
-        else:
-          return gsutil('ls', '-d', pattern)
-      except GsCommandException as e:
-        if GSUTIL_NO_MATCHES in str(e):
-          return []
-        raise
-    else:
-      # A small optimization: when the pattern itself is a dir (no glob
-      # was used) or the globbing '*' is used only at the last segment,
-      # we can just simply list dir which is *much* faster than globbing.
-      if isdir(pattern):
-        return [pattern.rstrip('/')]
-      elif pattern.endswith('/*') and isdir(pattern.rstrip('*')):
-        dir_base = pattern.rstrip('*')
-        ls = _import_gfile().listdir(dir_base)
-        return [os.path.join(dir_base, entry) for entry in ls]
-      else:
-        return _import_gfile().glob(pattern)  # noqa
-  else:
-    return local_glob(pattern)
+  return _choose_backend(pattern).glob(pattern)
 
 
 def exists(path: PathType) -> bool:
   """Similar to os.path.exists(path), but supports both local path and
   remote path (Google Cloud Storage, gs://...) via gfile.exists(...).
   """
-  path = _to_path_string(path)
-
-  if path.startswith('gs://'):
-    if USE_GSUTIL:
-      try:
-        return bool(gsutil('ls', '-d', path))
-      except GsCommandException as e:
-        if GSUTIL_NO_MATCHES in str(e):
-          return False
-        raise
-    else:
-      return _import_gfile().exists(path)  # noqa
-  else:
-    return os.path.exists(path)
+  return _choose_backend(path).exists(path)
 
 
 def isdir(path: PathType):
   """Similar to os.path.isdir(path), but supports both local path and
   remote path (Google Cloud Storage, gs://...) via gfile.isdir(...).
   """
-  path = _to_path_string(path)
-
-  if path.startswith('gs://'):
-    # Bug: GCP glob does not match any directory on trailing slashes.
-    # https://github.com/GoogleCloudPlatform/gsutil/issues/444
-    path = path.rstrip('/')
-    return _import_gfile().isdir(path)  # noqa
-  else:
-    return os.path.isdir(path)
+  return _choose_backend(path).isdir(path)
 
 
 # pylint: disable-next=redefined-builtin
@@ -166,9 +244,4 @@ def open(path: PathType, *, mode='r'):
   """Similar to built-in open(...), but supports Google Cloud Storage
   (i.e., gs://...) path via gfile.GFile(...) as well as local path.
   """
-  path = _to_path_string(path)
-
-  if path.startswith('gs://'):
-    return _import_gfile().GFile(path, mode=mode)  # noqa
-  else:
-    return io.open(path, mode=mode)
+  return _choose_backend(path).open(path, mode=mode)

--- a/expt/path_util_test.py
+++ b/expt/path_util_test.py
@@ -51,6 +51,40 @@ def test_local_file():
     assert 'episode_rewards' in line
 
 
+@pytest.mark.skipif('not os.getenv("EXPT_SSH_HOST")', \
+                    reason="Requires test SSH host set up manually")  # noqa
+@pytest.mark.parametrize("protocol", ["sftp", "scp"])
+def test_ssh(protocol: str):
+  """Tests sftp:// files."""
+  sys.stdout.write("ssh\n")
+
+  host = os.environ["EXPT_SSH_HOST"]
+  uri_base = f"{protocol}://{host}:2222"
+
+  bashrc = uri_base + "/.bashrc"
+  directory = uri_base + "/.ssh"
+  not_exist = uri_base + "/__NOT_EXIST__"
+
+  assert P.exists(bashrc) is True
+  assert P.exists(not_exist) is False
+
+  with P.open(bashrc) as f:
+    lines = f.readlines()
+  assert (lines.__len__() > 0)
+
+  assert P.isdir(bashrc) is False
+  assert P.isdir(directory) is True
+  assert P.isdir(not_exist) is False
+
+  glob = V(P.glob(uri_base + "/.*bash*"))
+  assert bashrc in glob
+
+  glob = V(P.glob(uri_base + "//etc/*bashrc*"))
+  assert glob
+
+  glob = V(P.glob(uri_base + "/.ss*/*s*"))
+
+
 @pytest.mark.slow
 def test_gcloud():
   """Tests gs:// files.

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ install_requires = [
     'matplotlib>=3.0.0',
     'pandas>=1.0',
     'multiprocess>=0.70.12',
+    'typing_extensions>=4.0',
 ]
 
 tests_requires = [

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,10 @@ tests_requires = [
     'pytest>=5.0',  # Python 3.5+
     'pytest-cov',
     'pytest-asyncio',
+    # Optional dependencies.
     'tensorboard>=2.3',
+    'fabric~=2.6',
+    'paramiko>=2.8',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ install_requires = [
     'pandas>=1.0',
     'multiprocess>=0.70.12',
     'typing_extensions>=4.0',
+    'python-slugify>=6.1.2',
 ]
 
 tests_requires = [


### PR DESCRIPTION
A part of #9.

- Refactor path_util to make abstraction over filesystem backends
- Add path_util to query and read from SSH remotes (SFTP, SCP)
- Add an initial support of fetching and parsing runs over ssh/sftp.

e.g.

```
  sftp://[username@]hostname[:port]/file/*.log
  sftp://[username@]hostname[:port]/foo.bar
  sftp://[username@]hostname[:port]//etc/bash.bashrc  (absolute path)
  scp://[username@]hostname[:port]/scp-protocol-is-also-supported
```