### PR TITLE
Add path_util.session() to cache and reuse SSH/SFTP connections

### DIFF
--- a/expt/data_loader.py
+++ b/expt/data_loader.py
@@ -581,6 +581,7 @@ class RunLoader:
       self._pool.close()
       self._pool = None
 
+  @path_util.session_wrap
   def add_paths(self, *path_globs):
     for path_glob in path_globs:
 

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ install_requires = [
     'matplotlib>=3.0.0',
     'pandas>=1.0',
     'multiprocess>=0.70.12',
+    'multiprocessing_utils==0.4',
     'typing_extensions>=4.0',
     'python-slugify>=6.1.2',
 ]


### PR DESCRIPTION
Handshaking and establishing SSH sessions (for SFTP) is expensive; consecutive and many numbers of path_util call while loading runs may take a lot of time if the SSH connection is not cached or re-used.

We add a context manager `path_util.session()`, within which SSH/SFTP connection resources can be cached and reused for a fast performance.

Part of #9 and improves the initial implementation in #10.